### PR TITLE
Add release workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ these settings:
     4. Click the green `Create` button at the bottom
 2. Automatically delete merged branches
     - Navigate to `Settings --> Options --> Merge button` and enable `Automatically delete head branches`.
+3. Add the `FORGE_API_KEY` secret from 1Password to `Settings --> Secrets --> Repository secrets`.
 
 ### Integrate with Jira
 
@@ -70,12 +71,12 @@ Please follow the instructions in [confluence](https://confluence.puppetlabs.com
 
 ### PDK & GitHub Actions
 
-It is expected that all modules here are utilizing the [PDK](https://puppet.com/docs/pdk/latest). `pdk validate` and `pdk test unit` is expected to pass both locally and via GitHub Actions with the file `ci.yml` included in this repo.
+It is expected that all modules here are utilizing the [PDK](https://puppet.com/docs/pdk/latest). `pdk validate` and `pdk test unit` is expected to pass both locally and via GitHub Actions with the file `pr_test.yml` included in this repo.
 
 Setup PDK and GitHub Actions:
 
-1. Copy `templates/ci.yml` in this repo to the destination repo to `.github/workflows/ci.yml`
-2. Copy `templates/.sync.yml` in this repo to the root of the destination repo.
+1. Copy `templates/pr_test.yml` and `templates/release.yml` to the destination repo in the `.github/workflows` directory.
+2. Copy `templates/.sync.yml` to the root of the destination repo.
     - You can now run `pdk update` or `pdk convert` to update the repo with the standard settings.
 
 ### metadata.json
@@ -120,7 +121,7 @@ It is expected that every module will have the following:
     ![](https://img.shields.io/puppetforge/pdk-version/ploperations/<MODULE-NAME>.svg?style=popout)
     ![](https://img.shields.io/puppetforge/v/ploperations/<MODULE-NAME>.svg?style=popout)
     ![](https://img.shields.io/puppetforge/dt/ploperations/<MODULE-NAME>.svg?style=popout)
-    [![Build Status](https://github.com/ploperations/ploperations-<MODULE-NAME>/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/ploperations/ploperations-<MODULE-NAME>/actions/workflows/ci.yml)
+    [![Build Status](https://github.com/ploperations/ploperations-<MODULE-NAME>/actions/workflows/pr_test.yml/badge.svg?branch=main)](https://github.com/ploperations/ploperations-<MODULE-NAME>/actions/workflows/pr_test.yml)
     ```
 
   - this at the bottom:
@@ -151,6 +152,10 @@ All modules should contain a `LICENSE` file. Generally, an Apache 2.0 license sh
 ### Puppet Forge
 
 Once all the above have been done it is expected that modules are deployed to the Puppet Forge under the `ploperations` user. Once that initial push has been done it is also expected that the `Puppetfile` in our control repo pulls from the Forge.
+
+Using the provided GitHub Actions template, a workflow can be manually triggered to tag a release on GitHub and publish the module to The Forge using the version specified in `metadata.json`.
+
+To trigger the workflow navigate to `Actions --> Workflows --> Publish Module --> Run workflow with main branch`. This workflow uses the `FORGE_API_KEY` setup in step 3 of the [Settings in the GitHub interface](#settings-in-the-github-interface).
 
 ## Contributions to these standards
 

--- a/templates/.sync.yml
+++ b/templates/.sync.yml
@@ -53,6 +53,7 @@ Gemfile:
       - gem: 'puppet-lint-version_comparison-check'
         version: '~> 0.2'
 Rakefile:
+  changelog_version_tag_pattern: '%s'
   linter_fail_on_warnings: true
   requires:
     - 'puppet-strings/tasks'

--- a/templates/pr_test.yml
+++ b/templates/pr_test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: PR Testing
 
 on:
   - pull_request
@@ -15,11 +15,11 @@ jobs:
     name: Puppet ${{ matrix.puppet_versions }}
     steps:
     - uses: actions/checkout@v1
-    - name: Install the Puppet PDK
+    - name: Install the PDK
       run: |
-        CODENAME=$(grep UBUNTU_CODENAME /etc/os-release | cut -d '=' -f2)
-        wget https://apt.puppet.com/puppet-tools-release-$CODENAME.deb
-        sudo dpkg -i puppet-tools-release-$CODENAME.deb
+        source /etc/os-release
+        wget https://apt.puppet.com/puppet-tools-release-${UBUNTU_CODENAME}.deb
+        sudo dpkg -i puppet-tools-release-${UBUNTU_CODENAME}.deb
         sudo apt-get update
         sudo apt-get install pdk
     - name: Syntax validation

--- a/templates/release.yml
+++ b/templates/release.yml
@@ -1,0 +1,78 @@
+name: Publish Module
+
+on: workflow_dispatch
+
+jobs:
+  publish-module:
+    name: Tag Release and Publish to Forge
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+          clean: true
+          fetch-depth: 0
+      - name: Get Version
+        id: gv
+        run: |
+          echo "::set-output name=ver::$(jq --raw-output .version metadata.json)"
+      - name: Install the PDK
+        run: |
+          source /etc/os-release
+          wget https://apt.puppet.com/puppet-tools-release-${UBUNTU_CODENAME}.deb
+          sudo dpkg -i puppet-tools-release-${UBUNTU_CODENAME}.deb
+          rm -f puppet-tools-release-${UBUNTU_CODENAME}.deb
+          sudo apt-get update
+          sudo apt-get install pdk
+          pdk bundle install
+      - name: Validate Docs
+        run: |
+          set -e
+          documentation=$(pdk bundle exec puppet strings generate --format markdown)
+          if [ $(echo $documentation | grep -Ec "[1-9]+ undocumented|\[warn\]") -gt 0 ]; then
+            echo "Please resolve documentation issues detected below:"
+            echo $documentation
+            exit 1
+          fi
+          if output=$(git status --porcelain) && [ ! -z "$output" ]; then
+            echo "Here is the current git status:"
+            git status
+            echo
+            echo "The following changes were detected:"
+            git --no-pager diff
+            echo "Please submit a PR of changes after running 'pdk bundle exec puppet strings generate --format markdown'"
+            exit 1
+          fi
+      - name: Validate Changelog
+        env:
+          CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          pdk bundle exec rake changelog
+          check_prs=$(grep -c '### UNCATEGORIZED PRS; LABEL THEM ON GITHUB' CHANGELOG.md) || echo "Check PRs success"
+          if [ $check_prs -gt 0 ]; then
+            echo "Uncategorized PRs found. Please address missing labels in the PRs below:"
+            git --no-pager diff CHANGELOG.md
+            exit 1
+          fi
+          if output=$(git status --porcelain) && [ ! -z "$output" ]; then
+            echo "Here is the current git status:"
+            git status
+            echo
+            echo "The following changes were detected:"
+            git --no-pager diff
+            echo "Uncommitted PRs found in the changelog. Please submit a PR of changes after running 'pdk bundle exec rake changelog'"
+            exit 1
+          fi
+      - name: Tag Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.gv.outputs.ver }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: false
+          prerelease: false
+      - name: Build Module
+        run: pdk build
+      - name: Push to Forge
+        run: pdk release publish --forge-token ${{ secrets.FORGE_API_KEY }} --force


### PR DESCRIPTION
This is a manually triggered workflow that would perform the following steps:
1. Get module version from `metadata.json`
2. Install the PDK
3. Create a GitHub release and tag latest commit using the version from step 1 (Uses https://github.com/ncipollo/release-action).
4. Build the module using PDK
5. Push to The Forge using the PDK (Need to add `FORGE_API_KEY` secret)

Validated scenarios for `release.yml` in a private repo:
- [x] Fail if missing documentation for a param.
- [x] Fail if missing documentation for a class.
- [x] Fail if everything is documented, but it's not committed.
- [x] Fail if changelog generator found uncategorized PRs
- [x] Fail if changelog generator found changes that are not committed
- [x] Fail tag release if tag already exists