### PR TITLE
Update github_changelog_generator to >= 1.16.4

### DIFF
--- a/templates/.sync.yml
+++ b/templates/.sync.yml
@@ -9,7 +9,7 @@ Gemfile:
   required:
     ':development':
       - gem: 'github_changelog_generator'
-        version: '~> 1.15'
+        version: "~> 1.16', '>= 1.16.4"
       - gem: 'puppet-lint-absolute_classname-check'
         version: '~> 3.0'
       - gem: 'puppet-lint-absolute_template_path'


### PR DESCRIPTION
There were changes to the output between 1.15.0 and 1.16.4 so this will ensure that all users are pulling at least 1.16.4.